### PR TITLE
Added call to saveName() when the name is queried

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 			}
 			if msg.ForwardFrom != nil {
 				handleSearch(msg, msg.ForwardFrom.ID)
+				go saveName(msg.ForwardFrom)
 				continue
 			}
 			handleUsage(msg)
@@ -57,6 +58,7 @@ func main() {
 				continue
 			}
 			handleSearch(msg, msg.ReplyToMessage.From.ID)
+			go saveName(msg.ReplyToMessage.From)
 		}
 	}
 }


### PR DESCRIPTION
It helps bot to remember more names. Moreover, users now can use the bot to save names of an arbitrary person from any chat.
Note: the call to saveName() was added after calls to handleSearch() because otherwise the behaviour was unpredictable: in some cases the bot was able to find newly saved name, in others it was not. It's possibly because redis queries are async or something like that idk